### PR TITLE
Add C# support

### DIFF
--- a/index.less
+++ b/index.less
@@ -9,6 +9,7 @@
 @import 'styles/languages/_base';
 @import 'styles/languages/c';
 @import 'styles/languages/coffee';
+@import 'styles/languages/cs';
 @import 'styles/languages/css';
 @import 'styles/languages/gfm';
 @import 'styles/languages/haskell';

--- a/styles/languages/cs.less
+++ b/styles/languages/cs.less
@@ -1,0 +1,8 @@
+.source.cs {
+  .meta {
+    .uno-3();
+  }
+  .method {
+    .uno-2();
+  }
+}


### PR DESCRIPTION
- `.meta` is more like a catch all since language-cs doesn't tokenize everything.

Ref: https://github.com/simurai/duotone-dark-syntax/pull/9
